### PR TITLE
fix: sandbox live build

### DIFF
--- a/liveOS/modules/bsd/main.tf
+++ b/liveOS/modules/bsd/main.tf
@@ -41,10 +41,10 @@ data "template_file" "liveos_bsd_meta_data" {
   template = file("${path.module}/cloudinit/meta-data")
 }
 
-resource "libvirt_network" "liveos_bsd_network" {
-  name = "liveos_bsd_network"
-  addresses = ["10.17.0.0/24"]
-}
+# resource "libvirt_network" "liveos_bsd_network" {
+#   name = "liveos_bsd_network"
+#   addresses = ["10.17.0.0/24"]
+# }
 
 resource "libvirt_cloudinit_disk" "liveos_bsd_cloudinit_disk" {
   name = "bsd_cloudinit.iso"
@@ -69,10 +69,10 @@ resource "libvirt_domain" "liveos_bsd_domain" {
     volume_id = libvirt_volume.liveos_bsd_disk.id
   }
   cloudinit = libvirt_cloudinit_disk.liveos_bsd_cloudinit_disk.id
-  network_interface {
-    network_id = libvirt_network.liveos_bsd_network.id
-    wait_for_lease = true
-  }
+  # network_interface {
+  #   network_id = libvirt_network.liveos_bsd_network.id
+  #   wait_for_lease = true
+  # }
   filesystem {
     source = "${var.cache_dir}/build_artifacts/bsdrepo"
     target = "shared"

--- a/liveOS/os.mk
+++ b/liveOS/os.mk
@@ -12,7 +12,6 @@ export TF_PLUGIN_CACHE_DIR
 os.clean:
 	@echo "Destroying resources..."
 	$(TF_BIN) -chdir=$(LIVEOS_DIR) destroy -auto-approve
-	rm $(CACHE_DIR)/output/*.iso
 
 os.init:
 	@echo "Initializing terraform..."

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -16,6 +16,24 @@ we need to configure:
 * Enable IP forwarding (so traffic can route from VMs to the internet)
 * Setup iptables MASQUERADE (so VM's traffic appears to come from the host)
 
+When launched, two network bridges are created:
+
+* `sandbox_WAN`: addresses `10.10.10.0/24`
+* `sandbox_LAN`: addresses `192.168.50.0/24`
+
+Where these are used to emulate the access point providing internet connectivity, and
+the local network, respectively.
+
+The VMs themselves are as follows:
+
+* `opnsense`: The router, using a real OPNsense image
+  * WAN: `10.10.10.11`
+  * LAN: `192.168.50.10`
+* `pikvm`: The centralized provisioner, using Debian cloud image, connected to LAN
+  * LAN: `192.168.50.11`
+* `liveos`: The image built by this project, using Debian, connected to LAN
+  * LAN: `192.168.50.12`
+
 ## Preparation
 
 Manual steps to setup the host:

--- a/shell.nix
+++ b/shell.nix
@@ -15,6 +15,7 @@
     kcl
     tflint
     cdrtools
+    tigervnc
   ];
 
   in pkgs.mkShell {


### PR DESCRIPTION
Replaces the emulated PiKVM instance with Debian cloud. Due to issues with the liveOS, not all the expected IPs show up on the network bridges, which is subject for a future PR